### PR TITLE
Quitado iframe, que llevaba al formulario de google en mi drive

### DIFF
--- a/eleccionExamen.php
+++ b/eleccionExamen.php
@@ -130,6 +130,10 @@
 						</thead>
 						<tbody>
 
+					<?php
+						/*
+							//Aquí estaba el link hacia el fichero con el iframe a google forms
+							//Actualmente quitado
 							<tr>
 								<td> Cuestionario sobre hábitos en el uso de videojuegos</td>
 								<td> e-valUAM </td>
@@ -137,7 +141,8 @@
 								<td> - </td>
 								<td><a class="btn btn-primary" href="gammingTest.php">Continuar</a></td>
 							</tr>
-
+						*/
+					?>
 
 							<?php
 								$result = pg_query_params($con, 'SELECT e.id, e.nombre, e.duracion,m.nombre AS materia,a.nombre AS asignatura 

--- a/gammingTest.php
+++ b/gammingTest.php
@@ -42,7 +42,7 @@
 		<?php mostrar_header_link(); ?>
 
 		<div style="text-align:center">
-				<iframe src="https://docs.google.com/forms/d/1ZUiJeYvg1Firk2gczNXXzEfNEXis-catw_p68hG2vqU/viewform?embedded=true" width="100%" height="2800" frameborder="0" marginheight="0" marginwidth="0">Cargando...</iframe>
+				<iframe src=" " width="100%" height="2800" frameborder="0" marginheight="0" marginwidth="0">Cargando...</iframe>
 		</div>
 			<?php //mostrar_licencia(); ?>
 	


### PR DESCRIPTION
Se ha dejado gammingTest.php (sin el link al iframe) por si puede servir como plantilla algún día.
Se podría eliminar perfectamente
